### PR TITLE
Adds CNAME record for get.superviz.io

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+get.superviz.io


### PR DESCRIPTION
Adds a CNAME record to enable serving the application from the get.superviz.io subdomain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated domain configuration for the site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->